### PR TITLE
feat: remove api key

### DIFF
--- a/Editor/FarlyDependencies.xml
+++ b/Editor/FarlyDependencies.xml
@@ -9,7 +9,7 @@
     </androidPackage>
     <androidPackage spec="com.google.code.gson:gson:2.9.0">
     </androidPackage>
-    <androidPackage spec="com.github.farly-sdk:farly-android-sdk:1.0.3">
+    <androidPackage spec="com.github.farly-sdk:farly-android-sdk:1.0.5">
     </androidPackage>
   </androidPackages>
 
@@ -44,7 +44,7 @@
          * "subspecs" (optional)
            Subspecs to include for the pod.
      -->
-    <iosPod name="Farly" version="~> 1.0.3">
+    <iosPod name="Farly" version="~> 1.0.5">
     </iosPod>
   </iosPods>
 </dependencies>

--- a/Plugins/Android/src/FarlyNativeAndroidSDK.java
+++ b/Plugins/Android/src/FarlyNativeAndroidSDK.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Date;
 
 interface FarlyNativeAndroidSDKPluginInterface {
-    void configure(String apiKey, String publisherId);
+    void configure(String publisherId);
 
     void getHostedOfferwallUrl(String requestJSON);
 
@@ -70,8 +70,7 @@ public class FarlyNativeAndroidSDK implements FarlyNativeAndroidSDKPluginInterfa
     }
 
     @Override
-    public void configure(String apiKey, String publisherId) {
-        Farly.getInstance().setApiKey(apiKey);
+    public void configure(String publisherId) {
         Farly.getInstance().setPublisherId(publisherId);
     }
 

--- a/Plugins/iOS/src/FarlyNativeIosSDK.mm
+++ b/Plugins/iOS/src/FarlyNativeIosSDK.mm
@@ -64,9 +64,8 @@ OfferWallRequest* ParseRequest (const char* string)
 }
 
 extern "C" {
-    void _configureFarly (const char* apiKey, const char* publisherId)
+    void _configureFarly (const char* publisherId)
     {
-        Farly.shared.apiKey = CreateNSString(apiKey);
         Farly.shared.publisherId = CreateNSString(publisherId);
     }
 

--- a/Runtime/FarlySDK.cs
+++ b/Runtime/FarlySDK.cs
@@ -17,7 +17,7 @@ namespace FarlySDK
 #if UNITY_IOS
     [DllImport("__Internal")]
 #endif
-    private static extern void _configureFarly(string apiKey, string publisherId);
+    private static extern void _configureFarly(string publisherId);
 #if UNITY_IOS
     [DllImport("__Internal")]
 #endif
@@ -95,16 +95,16 @@ namespace FarlySDK
       }
     }
 
-    public static string Configure(string apiKey, string publisherId)
+    public static string Configure(string publisherId)
     {
       switch (Application.platform)
       {
         case RuntimePlatform.Android:
-          androidJavaNative.Call("configure", apiKey, publisherId);
+          androidJavaNative.Call("configure", publisherId);
           return "ok";
 
         case RuntimePlatform.IPhonePlayer:
-          _configureFarly(apiKey, publisherId);
+          _configureFarly(publisherId);
           return "ok";
 
         default:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.farly.farly-unity-sdk",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "description": "Farly SDK for Unity",
   "displayName": "Farly Unity SDK",
   "documentationUrl": "https://github.com/farly-sdk/farly-unity-sdk"


### PR DESCRIPTION
passing the apiKey is not required anymore, the publisher id is enough.
